### PR TITLE
add auto generated protobuff output files

### DIFF
--- a/src/Catalyst.Node.Common/Catalyst.Node.Common.csproj
+++ b/src/Catalyst.Node.Common/Catalyst.Node.Common.csproj
@@ -167,11 +167,11 @@
     <Compile Include="..\..\submodules\cs-multibase\src\Multiformats.Base\LetterCasing.cs" Link="Helpers\Multiformats.Base\LetterCasing.cs" />
     <Compile Include="..\..\submodules\cs-multibase\src\Multiformats.Base\Multibase.cs" Link="Helpers\Multiformats.Base\Multibase.cs" />
     <Compile Include="..\..\submodules\cs-multibase\src\Multiformats.Base\MultibaseEncoding.cs" Link="Helpers\Multiformats.Base\MultibaseEncoding.cs" />
-    <Compile Include="obj\**\*\Common.cs" />
-    <Compile Include="obj\**\*\Delta.cs" />
-    <Compile Include="obj\**\*\IPPN.cs" />
-    <Compile Include="obj\**\*\Rpc.cs" />
-    <Compile Include="obj\**\*\Transaction.cs" />
+    <Compile Include="$(SolutionDir)\Catalyst.Node.Common\obj\$(Configuration)\$(TargetFrameWork)\Common.cs" Link="Protocol\Common.cs" />
+    <Compile Include="$(SolutionDir)\Catalyst.Node.Common\obj\$(Configuration)\$(TargetFrameWork)\Delta.cs" Link="Protocol\Delta.cs" />
+    <Compile Include="$(SolutionDir)\Catalyst.Node.Common\obj\$(Configuration)\$(TargetFrameWork)\IPPN.cs" Link="Protocol\IPPN.cs" />
+    <Compile Include="$(SolutionDir)\Catalyst.Node.Common\obj\$(Configuration)\$(TargetFrameWork)\Rpc.cs" Link="Protocol\Rpc.cs" />
+    <Compile Include="$(SolutionDir)\Catalyst.Node.Common\obj\$(Configuration)\$(TargetFrameWork)\Transaction.cs" Link="Protocol\Transaction.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\..\submodules\nsec\src\Cryptography\Error.resx" Link="Helpers\NSec\Cryptography\Error.resx">


### PR DESCRIPTION
Rider doesn't by default index files in obj/bin files. Since we auto generate protobuffs files there now as per this pull https://github.com/catalyst-network/Catalyst.Node/pull/277/files

This pull adds the ability to index autogenerated files in rider.