### PR TITLE
Hopefully more reliable cancelation tests

### DIFF
--- a/src/Catalyst.Node.Core.UnitTests/Modules/Dfs/IpfsDfsTests.cs
+++ b/src/Catalyst.Node.Core.UnitTests/Modules/Dfs/IpfsDfsTests.cs
@@ -39,8 +39,8 @@ namespace Catalyst.Node.Core.UnitTest.Modules.Dfs
 {
     public sealed class IpfsDfsTests : IDisposable
     {
-        private const int DelayInMs = 100;
-        private const int DelayMultiplier = 3;
+        private const int DelayInMs = 50;
+        private const int DelayMultiplier = 4;
         private readonly IIpfsEngine _ipfsEngine;
         private readonly ILogger _logger;
         private readonly Cid _expectedCid;
@@ -144,7 +144,7 @@ namespace Catalyst.Node.Core.UnitTest.Modules.Dfs
             _ipfsEngine.FileSystem.AddAsync(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<AddFileOptions>(), Arg.Any<CancellationToken>())
                .Returns(c =>
                 {
-                    Task.Delay(DelayInMs * 2, (CancellationToken) c[3]).GetAwaiter().GetResult();
+                    Task.Delay(DelayInMs * DelayMultiplier, (CancellationToken) c[3]).GetAwaiter().GetResult();
                     return Task.FromResult(_addedRecord);
                 });
 
@@ -162,7 +162,7 @@ namespace Catalyst.Node.Core.UnitTest.Modules.Dfs
             _ipfsEngine.FileSystem.ReadAllTextAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
                .Returns(c =>
                 {
-                    Task.Delay(DelayInMs * 2, (CancellationToken) c[1]).GetAwaiter().GetResult();
+                    Task.Delay(DelayInMs * DelayMultiplier, (CancellationToken) c[1]).GetAwaiter().GetResult();
                     return Task.FromResult("some content");
                 });
 
@@ -180,7 +180,7 @@ namespace Catalyst.Node.Core.UnitTest.Modules.Dfs
             _ipfsEngine.FileSystem.ReadFileAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
                .Returns(c =>
                 {
-                    Task.Delay(DelayInMs * 2, (CancellationToken) c[1]).GetAwaiter().GetResult();
+                    Task.Delay(DelayInMs * DelayMultiplier, (CancellationToken) c[1]).GetAwaiter().GetResult();
                     return Task.FromResult(Stream.Null);
                 });
 


### PR DESCRIPTION
My bad sorry I was not using `DelayMultiplier` where I thought I was. 😞 :rage4: 
I have increased it too and reduced the cancellation delay to avoid sitting around for too long.
It works all the time locally, hopefully, it will be equally reliable on the build servers