### PR TITLE
DFS config to instantiate one instance per lifetime

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.cs text eol=lf
 *.md text eol=lf
 COPYING text eol=lf
+*.dll text eol=crlf

--- a/src/Catalyst.Node.Core/Config/Modules/dfs.json
+++ b/src/Catalyst.Node.Core/Config/Modules/dfs.json
@@ -3,6 +3,7 @@
   "components": [
     {
         "type": "Catalyst.Node.Core.Modules.Dfs.IpfsDfs",
+        "instanceScope": "singleinstance",
         "services": [
             {
                 "type": "Catalyst.Common.Interfaces.Modules.Dfs.IDfs, Catalyst.Common"
@@ -11,6 +12,7 @@
     },
     {
         "type": "Catalyst.Node.Core.Modules.Dfs.IpfsEngine",
+        "instanceScope": "singleinstance",
         "services": [
             {
                 "type": "Catalyst.Node.Core.Modules.Dfs.IIpfsEngine"


### PR DESCRIPTION
Tell Autofac to explicitly only use one IPFS object per lifetime