### PR TITLE
Stopped CLI add/get file integration tests running till timeout

### DIFF
--- a/src/Catalyst.Cli.IntegrationTests/Commands/AddFileCommandTest.cs
+++ b/src/Catalyst.Cli.IntegrationTests/Commands/AddFileCommandTest.cs
@@ -66,7 +66,7 @@ namespace Catalyst.Cli.IntegrationTests.Commands
 
                 if (expectedResult)
                 {
-                    await TaskHelper.WaitFor(() => uploadFileTransferFactory.Keys.Length > 0, TimeSpan.FromSeconds(5));
+                    await TaskHelper.WaitForAsync(() => uploadFileTransferFactory.Keys.Length > 0, TimeSpan.FromSeconds(5));
 
                     uploadFileTransferFactory.GetFileTransferInformation(uploadFileTransferFactory.Keys.First())
                        .Expire();

--- a/src/Catalyst.Cli.IntegrationTests/Commands/GetFileCommandTest.cs
+++ b/src/Catalyst.Cli.IntegrationTests/Commands/GetFileCommandTest.cs
@@ -67,7 +67,7 @@ namespace Catalyst.Cli.IntegrationTests.Commands
                     shell.AdvancedShell.ParseCommand("getfile", "-n", "node1", "-f", fileHash, "-o", outputPath)
                 );
 
-                await TaskHelper.WaitFor(() => downloadFileFactory.Keys.Length > 0, TimeSpan.FromSeconds(5));
+                await TaskHelper.WaitForAsync(() => downloadFileFactory.Keys.Length > 0, TimeSpan.FromSeconds(5));
 
                 downloadFileFactory.GetFileTransferInformation(downloadFileFactory.Keys.First()).Expire();
 

--- a/src/Catalyst.TestUtils/TaskHelper.cs
+++ b/src/Catalyst.TestUtils/TaskHelper.cs
@@ -29,23 +29,25 @@ namespace Catalyst.TestUtils
 {
     public static class TaskHelper
     {
-        public static async Task WaitFor(Func<bool> condition, TimeSpan timespan)
+        public static async Task WaitForAsync(Func<bool> condition, TimeSpan timespan)
         {
-            CancellationTokenSource tokenSource = new CancellationTokenSource(timespan);
-            await Task.Run(() =>
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource(timespan))
             {
-                while (!tokenSource.IsCancellationRequested)
+                await Task.Run(() =>
                 {
-                    if (!condition())
+                    while (!tokenSource.IsCancellationRequested)
                     {
-                        Task.Delay(100).ConfigureAwait(false).GetAwaiter().GetResult();
+                        if (!condition())
+                        {
+                            Task.Delay(100).ConfigureAwait(false).GetAwaiter().GetResult();
+                        }
+                        else
+                        {
+                            return;
+                        }
                     }
-                    else
-                    {
-                        return;
-                    }
-                }
-            }, tokenSource.Token).ConfigureAwait(false);
+                }, tokenSource.Token).ConfigureAwait(false);
+            }
         }
 
 


### PR DESCRIPTION
### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [x] I have added tests to cover my changes.
4. [x] All new and existing tests passed.
5. [x] Have you lint your code locally prior to submission?
6. [x] Does your code follows the code style of this project?
7. [ ] Does your change require a change to the documentation.
    - [ ] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [x] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [x] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Expires the add/get file CLI integration tests

* **What is the current behavior?** (You can also link to an open issue here)
The CLI add/get file integration tests will run until the transfer expires. This causes the test to complete in 1 minute

* **What is the new behavior (if this is a feature change)?**
The file transfer is expired after running the test command

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
