### PR TITLE
DFS test

### DIFF
--- a/src/Catalyst.Node.Core.IntegrationTests/Modules/Dfs/DfsTest.cs
+++ b/src/Catalyst.Node.Core.IntegrationTests/Modules/Dfs/DfsTest.cs
@@ -56,30 +56,23 @@ namespace Catalyst.Node.Core.IntegrationTests.Modules.Dfs
             passwordReader.ReadSecurePassword().ReturnsForAnyArgs(TestPasswordReader.BuildSecureStringPassword("abcd"));
             _logger = Substitute.For<ILogger>();
             _ipfs = new IpfsAdapter(passwordReader, peerSettings, FileSystem, _logger);
+
+            // Starting IPFS takes a few seconds.  Do it here, so that individual
+            // test times are not affected.
+            _ipfs.Generic.IdAsync().Wait();
         }
 
         [Fact]
         [Trait(Traits.TestType, Traits.IntegrationTest)]
         public async Task DFS_should_add_and_read_text()
         {
-            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-
-            var linearBackOffRetryPolicy = Policy.Handle<TaskCanceledException>()
-               .WaitAndRetryAsync(5, retryAttempt =>
-                {
-                    var timeSpan = TimeSpan.FromMilliseconds(retryAttempt + 5);
-                    cts = new CancellationTokenSource(timeSpan);
-                    return timeSpan;
-                });
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
 
             const string text = "good morning";
             var dfs = new Core.Modules.Dfs.Dfs(_ipfs, _logger);
-            var id = await linearBackOffRetryPolicy.ExecuteAsync(
-                () => dfs.AddTextAsync(text, cts.Token)
-            );
-            var content = await linearBackOffRetryPolicy.ExecuteAsync(
-                () => dfs.ReadTextAsync(id, cts.Token)
-            );
+            var id = await dfs.AddTextAsync(text, cts.Token);
+            var content = await dfs.ReadTextAsync(id, cts.Token);
+
             content.Should().Be(text);
         }
 
@@ -87,7 +80,7 @@ namespace Catalyst.Node.Core.IntegrationTests.Modules.Dfs
         [Trait(Traits.TestType, Traits.IntegrationTest)]
         public async Task DFS_should_add_and_read_binary()
         {
-            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
             var binary = new byte[]
             {
                 1, 2, 3

--- a/src/Catalyst.Node.Core/Catalyst.Node.Core.csproj
+++ b/src/Catalyst.Node.Core/Catalyst.Node.Core.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="DotNetty.Common" Version="0.6.0" />
         <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
         <PackageReference Include="Ipfs.Core" Version="0.51.1" />
-        <PackageReference Include="Ipfs.Engine" Version="0.9.1" />
+        <PackageReference Include="Ipfs.Engine" Version="0.10.0" />
         <PackageReference Include="Ipfs.HttpGateway" Version="0.3.0" />
         <PackageReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />


### PR DESCRIPTION
 - A test was using linear backoff with milliseconds, it should be seconds.  But the underlying issue was that the first call to IPFS would take 2-5 seconds to startup and screwed up the timeouts for the test.

- Include new release of PeerTalk that fixes disposing of a PeerConnection.  Some tests were reporting pipeline broken.