### PR TITLE
renames To/FromAnySigned to new convention of To/FromProtocolMessage

### DIFF
--- a/src/Catalyst.Cli/Commands/GetVersionCommands.cs
+++ b/src/Catalyst.Cli/Commands/GetVersionCommands.cs
@@ -68,7 +68,7 @@ namespace Catalyst.Cli.Commands
                     _peerIdentifier
                 ));
 
-                node.SendMessage(request.ToAnySigned(_peerIdentifier.PeerId, Guid.NewGuid()));
+                node.SendMessage(request.ToProtocolMessage(_peerIdentifier.PeerId, Guid.NewGuid()));
             }
             catch (Exception e)
             {

--- a/src/Catalyst.Common.UnitTests/Extensions/ProtobufExtensionsTests.cs
+++ b/src/Catalyst.Common.UnitTests/Extensions/ProtobufExtensionsTests.cs
@@ -70,7 +70,7 @@ namespace Catalyst.Common.UnitTests.Extensions
         public static void ToAnySigned_should_happen_new_guid_to_request_if_not_specified()
         {
             //this ensures we won't get Guid.Empty and then a risk of mismatch;
-            var wrapped = new PingRequest().ToAnySigned(PeerIdHelper.GetPeerId("you"));
+            var wrapped = new PingRequest().ToProtocolMessage(PeerIdHelper.GetPeerId("you"));
             wrapped.CorrelationId.Should().NotBeEquivalentTo(Guid.Empty.ToByteString());
         }
 
@@ -83,12 +83,12 @@ namespace Catalyst.Common.UnitTests.Extensions
             var wrapped = new PeerId()
             {
                 ClientId = expectedContent.ToUtf8ByteString()
-            }.ToAnySigned(peerId, guid);
+            }.ToProtocolMessage(peerId, guid);
 
             wrapped.CorrelationId.ToGuid().Should().Be(guid);
             wrapped.PeerId.Should().Be(peerId);
             wrapped.TypeUrl.Should().Be(PeerId.Descriptor.ShortenedFullName());
-            wrapped.FromAnySigned<PeerId>().ClientId.Should().Equal(expectedContent.ToUtf8ByteString());
+            wrapped.FromProtocolMessage<PeerId>().ClientId.Should().Equal(expectedContent.ToUtf8ByteString());
         }
 
         [Fact(Skip = "fail")]
@@ -100,7 +100,7 @@ namespace Catalyst.Common.UnitTests.Extensions
             {
                 ClientId = expectedContent.ToUtf8ByteString()
             };
-            new Action(() => response.ToAnySigned(peerId))
+            new Action(() => response.ToProtocolMessage(peerId))
                .Should().Throw<ArgumentException>();
         }
 
@@ -108,16 +108,16 @@ namespace Catalyst.Common.UnitTests.Extensions
         public void Can_Recognize_Gossip_Message()
         {
             var peerIdentifier = PeerIdentifierHelper.GetPeerIdentifier("1");
-            var gossipMessage = new TransactionBroadcast().ToAnySigned(peerIdentifier.PeerId, Guid.NewGuid())
-               .ToAnySigned(peerIdentifier.PeerId, Guid.NewGuid());
-            gossipMessage.CheckIfMessageIsGossip().Should().BeTrue();
+            var gossipMessage = new TransactionBroadcast().ToProtocolMessage(peerIdentifier.PeerId, Guid.NewGuid())
+               .ToProtocolMessage(peerIdentifier.PeerId, Guid.NewGuid());
+            gossipMessage.CheckIfMessageIsBroadcast().Should().BeTrue();
 
-            var nonGossipMessage = new PingRequest().ToAnySigned(peerIdentifier.PeerId, Guid.NewGuid());
-            nonGossipMessage.CheckIfMessageIsGossip().Should().BeFalse();
+            var nonGossipMessage = new PingRequest().ToProtocolMessage(peerIdentifier.PeerId, Guid.NewGuid());
+            nonGossipMessage.CheckIfMessageIsBroadcast().Should().BeFalse();
 
-            var secondNonGossipMessage = new PingRequest().ToAnySigned(peerIdentifier.PeerId, Guid.NewGuid())
-               .ToAnySigned(peerIdentifier.PeerId, Guid.NewGuid());
-            secondNonGossipMessage.CheckIfMessageIsGossip().Should().BeFalse();
+            var secondNonGossipMessage = new PingRequest().ToProtocolMessage(peerIdentifier.PeerId, Guid.NewGuid())
+               .ToProtocolMessage(peerIdentifier.PeerId, Guid.NewGuid());
+            secondNonGossipMessage.CheckIfMessageIsBroadcast().Should().BeFalse();
         }
     }
 }

--- a/src/Catalyst.Common.UnitTests/IO/Messaging/MessageHandlerBaseTests.cs
+++ b/src/Catalyst.Common.UnitTests/IO/Messaging/MessageHandlerBaseTests.cs
@@ -61,7 +61,7 @@ namespace Catalyst.Common.UnitTests.IO.Messaging
             _responseMessages = Enumerable.Range(0, 10).Select(i =>
             {
                 var message = new GetInfoResponse {Query = i.ToString()};
-                return message.ToAnySigned(
+                return message.ToProtocolMessage(
                     PeerIdentifierHelper.GetPeerIdentifier(i.ToString()).PeerId,
                     Guid.NewGuid());
             }).ToArray();
@@ -89,7 +89,7 @@ namespace Catalyst.Common.UnitTests.IO.Messaging
 
             foreach (var payload in _responseMessages)
             {
-                if (payload.FromAnySigned<GetInfoResponse>().Query == 5.ToString())
+                if (payload.FromProtocolMessage<GetInfoResponse>().Query == 5.ToString())
                 {
                     erroringStream.OnError(new DataMisalignedException("5 erred"));
                 }
@@ -107,11 +107,11 @@ namespace Catalyst.Common.UnitTests.IO.Messaging
         [Fact]
         public async Task MessageHandler_should_not_receive_messages_of_the_wrong_type()
         {
-            _responseMessages[3] = new PingResponse().ToAnySigned(
+            _responseMessages[3] = new PingResponse().ToProtocolMessage(
                 _responseMessages[3].PeerId, 
                 _responseMessages[3].CorrelationId.ToGuid());
 
-            _responseMessages[7] = new PingRequest().ToAnySigned(
+            _responseMessages[7] = new PingRequest().ToProtocolMessage(
                 _responseMessages[7].PeerId,
                 _responseMessages[7].CorrelationId.ToGuid());
 

--- a/src/Catalyst.Common.UnitTests/IO/Outbound/Handlers/ProtocolMessageSignHandlerTest.cs
+++ b/src/Catalyst.Common.UnitTests/IO/Outbound/Handlers/ProtocolMessageSignHandlerTest.cs
@@ -47,7 +47,7 @@ namespace Catalyst.Common.UnitTests.IO.Outbound.Handlers
             _fakeContext = Substitute.For<IChannelHandlerContext>();
             _keySigner = Substitute.For<IKeySigner>();
 
-            _protocolMessage = new PingRequest().ToAnySigned(
+            _protocolMessage = new PingRequest().ToProtocolMessage(
                 PeerIdentifierHelper.GetPeerIdentifier(
                     ByteUtil.GenerateRandomByteArray(32).ToString()
                 ).PeerId

--- a/src/Catalyst.Common/Extensions/ProtobufExtensions.cs
+++ b/src/Catalyst.Common/Extensions/ProtobufExtensions.cs
@@ -72,7 +72,7 @@ namespace Catalyst.Common.Extensions
             return ShortenedFullName(descriptor);
         }
 
-        public static ProtocolMessage ToAnySigned(this IMessage protobufObject,
+        public static ProtocolMessage ToProtocolMessage(this IMessage protobufObject,
             PeerId senderId,
             Guid correlationId = default)
         {
@@ -86,30 +86,21 @@ namespace Catalyst.Common.Extensions
             {
                 PeerId = senderId,
                 CorrelationId = (correlationId == default ? Guid.NewGuid() : correlationId).ToByteString(),
-
-                //todo: sign the `correlationId` and `value` bytes with publicKey instead
-                // Signature = senderId.PublicKey,
+                
                 TypeUrl = typeUrl,
                 Value = protobufObject.ToByteString()
             };
             return protocolMessage;
         }
 
-        public static bool CheckIfMessageIsGossip(this ProtocolMessage message)
+        public static bool CheckIfMessageIsBroadcast(this ProtocolMessage message)
         {
             return message.TypeUrl.EndsWith(nameof(ProtocolMessage)) &&
                 ProtoGossipAllowedMessages.Contains(ProtocolMessage.Parser.ParseFrom(message.Value).TypeUrl);
         }
 
-        public static T FromAnySigned<T>(this ProtocolMessage message) where T : IMessage<T>
+        public static T FromProtocolMessage<T>(this ProtocolMessage message) where T : IMessage<T>
         {
-            // Should need to do this as we do it in handler
-            // //todo check the message signature with the PeerId.PublicKey and value fields
-            // if (message.PeerId.PublicKey != message.Signature)
-            // {
-            //     throw new CryptographicException("Signature of the message doesn't match with sender's public Key");
-            // }
-    
             var empty = (T) Activator.CreateInstance(typeof(T));
             var typed = (T) empty.Descriptor.Parser.ParseFrom(message.Value);
             return typed;

--- a/src/Catalyst.Common/IO/Inbound/Handlers/CorrelationHandler.cs
+++ b/src/Catalyst.Common/IO/Inbound/Handlers/CorrelationHandler.cs
@@ -39,7 +39,7 @@ namespace Catalyst.Common.IO.Inbound.Handlers
 
         protected override void ChannelRead0(IChannelHandlerContext ctx, ProtocolMessage message)
         {
-            if (message.CheckIfMessageIsGossip())
+            if (message.CheckIfMessageIsBroadcast())
             {
                 ctx.FireChannelRead(message);
             }

--- a/src/Catalyst.Common/IO/Inbound/Handlers/GossipHandler.cs
+++ b/src/Catalyst.Common/IO/Inbound/Handlers/GossipHandler.cs
@@ -54,7 +54,7 @@ namespace Catalyst.Common.IO.Inbound.Handlers
         /// <param name="msg">The gossip message.</param>
         protected override void ChannelRead0(IChannelHandlerContext ctx, ProtocolMessage msg)
         {
-            if (msg.CheckIfMessageIsGossip())
+            if (msg.CheckIfMessageIsBroadcast())
             {
                 _gossipManager.ReceiveAsync(msg).ConfigureAwait(false).GetAwaiter().GetResult();
 

--- a/src/Catalyst.Common/IO/Messaging/MessageFactory.cs
+++ b/src/Catalyst.Common/IO/Messaging/MessageFactory.cs
@@ -80,7 +80,7 @@ namespace Catalyst.Common.IO.Messaging
         {
             return correlationId == default
                 ? throw new ArgumentException("Correlation ID cannot be null for a tell message")
-                : dto.Message.ToAnySigned(dto.Sender.PeerId, correlationId);
+                : dto.Message.ToProtocolMessage(dto.Sender.PeerId, correlationId);
         }
 
         /// <summary>Builds the ask message.</summary>
@@ -88,7 +88,7 @@ namespace Catalyst.Common.IO.Messaging
         /// <returns>ProtocolMessage message</returns>
         private ProtocolMessage BuildAskMessage(IMessageDto dto)
         {
-            var messageContent = dto.Message.ToAnySigned(dto.Sender.PeerId, Guid.NewGuid());
+            var messageContent = dto.Message.ToProtocolMessage(dto.Sender.PeerId, Guid.NewGuid());
             var correlatableRequest = new PendingRequest
             {
                 Content = messageContent,
@@ -104,7 +104,7 @@ namespace Catalyst.Common.IO.Messaging
         /// <returns>ProtocolMessage message</returns>
         private ProtocolMessage BuildGossipMessage(IMessageDto dto)
         {
-            return dto.Message.ToAnySigned(dto.Sender.PeerId, Guid.NewGuid());
+            return dto.Message.ToProtocolMessage(dto.Sender.PeerId, Guid.NewGuid());
         }
     }
 }

--- a/src/Catalyst.Node.Core.IntegrationTests/Modules/Dfs/NodeFileTransferIntegrationTest.cs
+++ b/src/Catalyst.Node.Core.IntegrationTests/Modules/Dfs/NodeFileTransferIntegrationTest.cs
@@ -156,7 +156,7 @@ namespace Catalyst.Node.Core.IntegrationTests.Modules.Dfs
                 Node = "node1",
                 FileName = fileToTransfer,
                 FileSize = (ulong) byteSize
-            }.ToAnySigned(sender, uniqueFileKey);
+            }.ToProtocolMessage(sender, uniqueFileKey);
             request.SendToHandler(_fakeContext, addFileToDfsRequestHandler);
             
             Assert.Single(_nodeFileTransferFactory.Keys);

--- a/src/Catalyst.Node.Core.IntegrationTests/P2P/PeerCorrelationCacheIntegrationTest.cs
+++ b/src/Catalyst.Node.Core.IntegrationTests/P2P/PeerCorrelationCacheIntegrationTest.cs
@@ -76,7 +76,7 @@ namespace Catalyst.Node.Core.IntegrationTests.P2P
                 })
                .Select(c => new PendingRequest
                 {
-                    Content = new PingRequest().ToAnySigned(senderPeerId, c.CorrelationId),
+                    Content = new PingRequest().ToProtocolMessage(senderPeerId, c.CorrelationId),
                     Recipient = c.PeerIdentifier,
                     SentAt = DateTimeOffset.MinValue
                 }).ToList();

--- a/src/Catalyst.Node.Core.IntegrationTests/P2P/PeerDiscoveryntergrationTest.cs
+++ b/src/Catalyst.Node.Core.IntegrationTests/P2P/PeerDiscoveryntergrationTest.cs
@@ -156,7 +156,7 @@ namespace Catalyst.Node.Core.IntegrationTests.P2P
             var pingRequest = new PingResponse();
             var pid = PeerIdentifierHelper.GetPeerIdentifier("im_a_key");
             var channeledAny = new ProtocolMessageDto(fakeContext, 
-                pingRequest.ToAnySigned(pid.PeerId, Guid.NewGuid()));
+                pingRequest.ToProtocolMessage(pid.PeerId, Guid.NewGuid()));
             
             var observableStream = new[] {channeledAny}.ToObservable();
 

--- a/src/Catalyst.Node.Core.UnitTests/P2P/MessageCorrelationCacheTests.cs
+++ b/src/Catalyst.Node.Core.UnitTests/P2P/MessageCorrelationCacheTests.cs
@@ -68,7 +68,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P
             _reputationByPeerIdentifier = _peerIds.ToDictionary(p => p, p => 0);
             _pendingRequests = _peerIds.Select((p, i) => new PendingRequest
             {
-                Content = new PingRequest().ToAnySigned(senderPeerId, Guid.NewGuid()),
+                Content = new PingRequest().ToProtocolMessage(senderPeerId, Guid.NewGuid()),
                 Recipient = p,
                 SentAt = DateTimeOffset.MinValue.Add(TimeSpan.FromMilliseconds(100 * i))
             }).ToList();
@@ -96,7 +96,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P
         [Fact]
         public void TryMatchResponseAsync_should_match_existing_records_with_matching_correlation_id()
         {
-            var responseMatchingIndex1 = new PingResponse().ToAnySigned(
+            var responseMatchingIndex1 = new PingResponse().ToProtocolMessage(
                 _peerIds[1].PeerId,
                 _pendingRequests[1].Content.CorrelationId.ToGuid());
 
@@ -120,7 +120,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P
         public void UncorrelatedMessage_should_decrease_reputation()
         {
             var reputationBefore = _reputationByPeerIdentifier[_peerIds[1]];
-            var responseMatchingIndex1 = new PingResponse().ToAnySigned(
+            var responseMatchingIndex1 = new PingResponse().ToProtocolMessage(
                 _peerIds[1].PeerId,
                 Guid.NewGuid());
 
@@ -134,7 +134,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P
         {
             var fakeContext = Substitute.For<IChannelHandlerContext>();
             var fakeChannel = Substitute.For<IChannel>();
-            var nonCorrelatedMessage = new PingResponse().ToAnySigned(_peerIds[0].PeerId, Guid.NewGuid());
+            var nonCorrelatedMessage = new PingResponse().ToProtocolMessage(_peerIds[0].PeerId, Guid.NewGuid());
 
             fakeContext.Channel.Returns(fakeChannel);
 
@@ -150,7 +150,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P
         [Fact]
         public void TryMatchResponseAsync_should_not_match_existing_records_with_non_matching_correlation_id()
         {
-            var responseMatchingNothing = new PingResponse().ToAnySigned(_peerIds[1].PeerId, Guid.NewGuid());
+            var responseMatchingNothing = new PingResponse().ToProtocolMessage(_peerIds[1].PeerId, Guid.NewGuid());
          
             // var request = _cache.TryMatchResponse<PingRequest, PingResponse>(responseMatchingNothing);
             // request.Should().BeNull();

--- a/src/Catalyst.Node.Core.UnitTests/P2P/Messaging/Gossip/GossipManagerTests.cs
+++ b/src/Catalyst.Node.Core.UnitTests/P2P/Messaging/Gossip/GossipManagerTests.cs
@@ -110,8 +110,8 @@ namespace Catalyst.Node.Core.UnitTests.P2P.Messaging.Gossip
             );
 
             var transaction = new TransactionBroadcast();
-            var anySigned = transaction.ToAnySigned(peerIdentifier.PeerId, guid)
-               .ToAnySigned(peerIdentifier.PeerId, Guid.NewGuid());
+            var anySigned = transaction.ToProtocolMessage(peerIdentifier.PeerId, guid)
+               .ToProtocolMessage(peerIdentifier.PeerId, Guid.NewGuid());
 
             channel.WriteInbound(anySigned);
 
@@ -133,8 +133,8 @@ namespace Catalyst.Node.Core.UnitTests.P2P.Messaging.Gossip
             var channel = new EmbeddedChannel(gossipHandler, protoDatagramChannelHandler);
 
             var anySignedGossip = new TransactionBroadcast()
-               .ToAnySigned(PeerIdHelper.GetPeerId(Guid.NewGuid().ToString()))
-               .ToAnySigned(PeerIdHelper.GetPeerId(Guid.NewGuid().ToString()));
+               .ToProtocolMessage(PeerIdHelper.GetPeerId(Guid.NewGuid().ToString()))
+               .ToProtocolMessage(PeerIdHelper.GetPeerId(Guid.NewGuid().ToString()));
 
             channel.WriteInbound(anySignedGossip);
             void CheckHandlerTestAction() => handler.SubstituteObserver.Received(1).OnNext(Arg.Any<TransactionBroadcast>());
@@ -181,7 +181,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P.Messaging.Gossip
                 correlationId
             );
 
-            var gossipDto = messageDto.ToAnySigned(senderIdentifier.PeerId, correlationId);
+            var gossipDto = messageDto.ToProtocolMessage(senderIdentifier.PeerId, correlationId);
 
             await gossipMessageHandler.ReceiveAsync(gossipDto);
             await gossipMessageHandler.BroadcastAsync(messageDto);

--- a/src/Catalyst.Node.Core.UnitTests/P2P/Messaging/Handlers/AddFileToDfsRequestHandlerTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/P2P/Messaging/Handlers/AddFileToDfsRequestHandlerTest.cs
@@ -69,7 +69,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P.Messaging.Handlers
                 Node = "node1",
                 FileName = "Test.dat",
                 FileSize = 10000
-            }.ToAnySigned(sender, Guid.NewGuid());
+            }.ToProtocolMessage(sender, Guid.NewGuid());
             request.SendToHandler(_fakeContext, handler);
 
             Assert.Equal(1, _nodeFileTransferFactory.Keys.Length);

--- a/src/Catalyst.Node.Core.UnitTests/P2P/Messaging/Handlers/GetNeighbourRequestHandlerTests.cs
+++ b/src/Catalyst.Node.Core.UnitTests/P2P/Messaging/Handlers/GetNeighbourRequestHandlerTests.cs
@@ -128,7 +128,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P.Messaging.Handlers
             var peerNeighbourRequestMessage = new PeerNeighborsRequest();
             
             var fakeContext = Substitute.For<IChannelHandlerContext>();
-            var channeledAny = new ProtocolMessageDto(fakeContext, peerNeighbourRequestMessage.ToAnySigned(PeerIdHelper.GetPeerId(), Guid.NewGuid()));
+            var channeledAny = new ProtocolMessageDto(fakeContext, peerNeighbourRequestMessage.ToProtocolMessage(PeerIdHelper.GetPeerId(), Guid.NewGuid()));
             var observableStream = new[] {channeledAny}.ToObservable();
             
             neighbourRequestHandler.StartObserving(observableStream);
@@ -143,7 +143,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P.Messaging.Handlers
             await observableStream.WaitForEndOfDelayedStreamOnTaskPoolScheduler();
 
             await fakeContext.Channel.ReceivedWithAnyArgs(1)
-               .WriteAndFlushAsync(peerNeighborsResponseMessage.ToAnySigned(_peerIdentifier.PeerId, Guid.NewGuid()));
+               .WriteAndFlushAsync(peerNeighborsResponseMessage.ToProtocolMessage(_peerIdentifier.PeerId, Guid.NewGuid()));
         }
     }
 }

--- a/src/Catalyst.Node.Core.UnitTests/P2P/Messaging/Handlers/GetNeighbourResponseHandlerTests.cs
+++ b/src/Catalyst.Node.Core.UnitTests/P2P/Messaging/Handlers/GetNeighbourResponseHandlerTests.cs
@@ -82,7 +82,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P.Messaging.Handlers
             var peerNeighbourResponseMessage = new PeerNeighborsResponse();
             
             var fakeContext = Substitute.For<IChannelHandlerContext>();
-            var channeledAny = new ProtocolMessageDto(fakeContext, peerNeighbourResponseMessage.ToAnySigned(PeerIdHelper.GetPeerId(), Guid.NewGuid()));
+            var channeledAny = new ProtocolMessageDto(fakeContext, peerNeighbourResponseMessage.ToProtocolMessage(PeerIdHelper.GetPeerId(), Guid.NewGuid()));
             var observableStream = new[] {channeledAny}.ToObservable();
             neighbourResponseHandler.StartObserving(observableStream);
 
@@ -96,7 +96,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P.Messaging.Handlers
             var peerNeighbourResponseMessage = new PeerNeighborsResponse();
             
             var fakeContext = Substitute.For<IChannelHandlerContext>();
-            var channeledAny = new ProtocolMessageDto(fakeContext, peerNeighbourResponseMessage.ToAnySigned(PeerIdHelper.GetPeerId(), Guid.NewGuid()));
+            var channeledAny = new ProtocolMessageDto(fakeContext, peerNeighbourResponseMessage.ToProtocolMessage(PeerIdHelper.GetPeerId(), Guid.NewGuid()));
             var observableStream = new[] {channeledAny}.ToObservable();
             subbedPeerDiscovery.StartObserving(observableStream);
             subbedPeerDiscovery.GetNeighbourResponseStream.ReceivedWithAnyArgs(1);

--- a/src/Catalyst.Node.Core.UnitTests/P2P/PeerServiceTests.cs
+++ b/src/Catalyst.Node.Core.UnitTests/P2P/PeerServiceTests.cs
@@ -76,7 +76,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P
         public async Task Can_receive_incoming_ping_responses()
         {
             var pingHandler = new TestMessageHandler<PingResponse>(_logger);
-            var protocolMessage = new PingResponse().ToAnySigned(_pid.PeerId, _guid);
+            var protocolMessage = new PingResponse().ToProtocolMessage(_pid.PeerId, _guid);
 
             await InitialisePeerServiceAndSendMessage(pingHandler, protocolMessage).ConfigureAwait(false);
 
@@ -87,7 +87,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P
         public async Task Can_receive_PingRequest()
         {
             var pingRequestHandler = new TestMessageHandler<PingRequest>(_logger);
-            var request = new PingRequest().ToAnySigned(_pid.PeerId, _guid);
+            var request = new PingRequest().ToProtocolMessage(_pid.PeerId, _guid);
 
             await InitialisePeerServiceAndSendMessage(pingRequestHandler, request).ConfigureAwait(false);
 
@@ -98,7 +98,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P
         public async Task Can_receive_PeerNeighborsRequest()
         {
             var pingRequestHandler = new TestMessageHandler<PeerNeighborsRequest>(_logger);
-            var request = new PeerNeighborsRequest().ToAnySigned(_pid.PeerId, _guid);
+            var request = new PeerNeighborsRequest().ToProtocolMessage(_pid.PeerId, _guid);
 
             await InitialisePeerServiceAndSendMessage(pingRequestHandler, request).ConfigureAwait(false);
 
@@ -113,7 +113,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P
             var responseContent = new PeerNeighborsResponse();
             responseContent.Peers.AddRange(neighbourIds);
 
-            var response = responseContent.ToAnySigned(_pid.PeerId, _guid);
+            var response = responseContent.ToProtocolMessage(_pid.PeerId, _guid);
 
             await InitialisePeerServiceAndSendMessage(pingRequestHandler, response).ConfigureAwait(false);
 

--- a/src/Catalyst.Node.Core.UnitTests/RPC/GetFileFromDfsRequestHandlerTests.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/GetFileFromDfsRequestHandlerTests.cs
@@ -96,7 +96,7 @@ namespace Catalyst.Node.Core.UnitTests.RPC
                 DfsHash = "test"
             };
             var protocolMessage = getFileFromDfsRequestMessage
-               .ToAnySigned(PeerIdHelper.GetPeerId("TestMan"), Guid.NewGuid());
+               .ToProtocolMessage(PeerIdHelper.GetPeerId("TestMan"), Guid.NewGuid());
             return new ProtocolMessageDto(Substitute.For<IChannelHandlerContext>(), protocolMessage);
         }
     }

--- a/src/Catalyst.Node.Core.UnitTests/RPC/GetInfoRequestHandlerTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/GetInfoRequestHandlerTest.cs
@@ -103,7 +103,7 @@ namespace Catalyst.Node.Core.UnitTests.RPC
             var sentResponse = (ProtocolMessage) receivedCalls.Single().GetArguments().Single();
             sentResponse.TypeUrl.Should().Be(GetInfoResponse.Descriptor.ShortenedFullName());
 
-            var responseContent = sentResponse.FromAnySigned<GetInfoResponse>();
+            var responseContent = sentResponse.FromProtocolMessage<GetInfoResponse>();
             responseContent.Query.Should()
                .Match(JsonConvert.SerializeObject(_config.GetSection("CatalystNodeConfiguration").AsEnumerable(),
                     Formatting.Indented));

--- a/src/Catalyst.Node.Core.UnitTests/RPC/GetMempoolRequestHandlerTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/GetMempoolRequestHandlerTest.cs
@@ -109,7 +109,7 @@ namespace Catalyst.Node.Core.UnitTests.RPC
             
             var sentResponse = (ProtocolMessage) receivedCalls.Single().GetArguments().Single();
             sentResponse.TypeUrl.Should().Be(GetMempoolResponse.Descriptor.ShortenedFullName());
-            var responseContent = sentResponse.FromAnySigned<GetMempoolResponse>();
+            var responseContent = sentResponse.FromProtocolMessage<GetMempoolResponse>();
 
             if (expectedTxs == 0)
             {

--- a/src/Catalyst.Node.Core.UnitTests/RPC/GetVersionRequestHandlerTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/GetVersionRequestHandlerTest.cs
@@ -80,7 +80,7 @@ namespace Catalyst.Node.Core.UnitTests.RPC
             var sentResponse = (ProtocolMessage) receivedCalls.Single().GetArguments().Single();
             sentResponse.TypeUrl.Should().Be(VersionResponse.Descriptor.ShortenedFullName());
 
-            var responseContent = sentResponse.FromAnySigned<VersionResponse>();
+            var responseContent = sentResponse.FromProtocolMessage<VersionResponse>();
             responseContent.Version.Should().Be(NodeUtil.GetVersion());
         }
     }

--- a/src/Catalyst.Node.Core.UnitTests/RPC/PeerBlackListingRequestHandlerTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/PeerBlackListingRequestHandlerTest.cs
@@ -159,7 +159,7 @@ namespace Catalyst.Node.Core.UnitTests.RPC
             var sentResponse = (ProtocolMessage) receivedCalls[0].GetArguments().Single();
             sentResponse.TypeUrl.Should().Be(SetPeerBlackListResponse.Descriptor.ShortenedFullName());
 
-            return sentResponse.FromAnySigned<SetPeerBlackListResponse>();
+            return sentResponse.FromProtocolMessage<SetPeerBlackListResponse>();
         }
     }
 }

--- a/src/Catalyst.Node.Core.UnitTests/RPC/PeerCountRequestHandlerTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/PeerCountRequestHandlerTest.cs
@@ -115,7 +115,7 @@ namespace Catalyst.Node.Core.UnitTests.RPC
             var sentResponse = (ProtocolMessage) receivedCalls[0].GetArguments().Single();
             sentResponse.TypeUrl.Should().Be(GetPeerCountResponse.Descriptor.ShortenedFullName());
 
-            var responseContent = sentResponse.FromAnySigned<GetPeerCountResponse>();
+            var responseContent = sentResponse.FromProtocolMessage<GetPeerCountResponse>();
 
             responseContent.PeerCount.Should().Be(fakePeers);
         }

--- a/src/Catalyst.Node.Core.UnitTests/RPC/PeerListRequestHandlerTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/PeerListRequestHandlerTest.cs
@@ -116,7 +116,7 @@ namespace Catalyst.Node.Core.UnitTests.RPC
             var sentResponse = (ProtocolMessage) receivedCalls[0].GetArguments().Single();
             sentResponse.TypeUrl.Should().Be(GetPeerListResponse.Descriptor.ShortenedFullName());
 
-            var responseContent = sentResponse.FromAnySigned<GetPeerListResponse>();
+            var responseContent = sentResponse.FromProtocolMessage<GetPeerListResponse>();
 
             responseContent.Peers.Count.Should().Be(fakePeers.Length);
         }

--- a/src/Catalyst.Node.Core.UnitTests/RPC/PeerReputationRequestHandlerTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/PeerReputationRequestHandlerTest.cs
@@ -152,7 +152,7 @@ namespace Catalyst.Node.Core.UnitTests.RPC
             var sentResponse = (ProtocolMessage) receivedCalls[0].GetArguments().Single();
             sentResponse.TypeUrl.Should().Be(GetPeerReputationResponse.Descriptor.ShortenedFullName());
 
-            return sentResponse.FromAnySigned<GetPeerReputationResponse>();
+            return sentResponse.FromProtocolMessage<GetPeerReputationResponse>();
         }
     }
 }

--- a/src/Catalyst.Node.Core.UnitTests/RPC/RemovePeerRequestHandlerTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/RemovePeerRequestHandlerTest.cs
@@ -136,7 +136,7 @@ namespace Catalyst.Node.Core.UnitTests.RPC
             var sentResponse = (ProtocolMessage) receivedCalls[0].GetArguments().Single();
             sentResponse.TypeUrl.Should().Be(RemovePeerResponse.Descriptor.ShortenedFullName());
 
-            var responseContent = sentResponse.FromAnySigned<RemovePeerResponse>();
+            var responseContent = sentResponse.FromProtocolMessage<RemovePeerResponse>();
 
             responseContent.DeletedCount.Should().Be(withPublicKey ? 1 : (uint) fakePeers.Count);
         }

--- a/src/Catalyst.Node.Core.UnitTests/RPC/SignMessageRequestHandlerTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/SignMessageRequestHandlerTest.cs
@@ -103,7 +103,7 @@ namespace Catalyst.Node.Core.UnitTests.RPC
             var sentResponse = (ProtocolMessage) receivedCalls.Single().GetArguments().Single();
             sentResponse.TypeUrl.Should().Be(SignMessageResponse.Descriptor.ShortenedFullName());
             
-            var responseContent = sentResponse.FromAnySigned<SignMessageResponse>();
+            var responseContent = sentResponse.FromProtocolMessage<SignMessageResponse>();
             
             responseContent.OriginalMessage.Should().Equal(message);
             

--- a/src/Catalyst.Node.Core.UnitTests/RPC/TransferFileBytesRequestHandlerTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/TransferFileBytesRequestHandlerTest.cs
@@ -67,7 +67,7 @@ namespace Catalyst.Node.Core.UnitTests.RPC
                 ChunkBytes = ByteString.Empty,
                 ChunkId = 1,
                 CorrelationFileName = Guid.NewGuid().ToByteString()
-            }.ToAnySigned(PeerIdHelper.GetPeerId("Test"), guid);
+            }.ToProtocolMessage(PeerIdHelper.GetPeerId("Test"), guid);
             request.SendToHandler(_context, _handler);
 
             _downloadFileTransferFactory.Received(1).DownloadChunk(Arg.Any<Guid>(), Arg.Any<uint>(), Arg.Any<byte[]>());
@@ -82,11 +82,11 @@ namespace Catalyst.Node.Core.UnitTests.RPC
                 ChunkBytes = ByteString.Empty,
                 ChunkId = 1,
                 CorrelationFileName = ByteString.Empty
-            }.ToAnySigned(PeerIdHelper.GetPeerId("Test"), guid);
+            }.ToProtocolMessage(PeerIdHelper.GetPeerId("Test"), guid);
             request.SendToHandler(_context, _handler);
             _context.Channel.Received().WriteAndFlushAsync(
                 Arg.Is<ProtocolMessage>(signed =>
-                    signed.FromAnySigned<TransferFileBytesResponse>().ResponseCode[0] == 
+                    signed.FromProtocolMessage<TransferFileBytesResponse>().ResponseCode[0] == 
                     (byte) FileTransferResponseCodes.Error));
         }
     }

--- a/src/Catalyst.Node.Core.UnitTests/RPC/VerifyMessageRequestHandlerTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/VerifyMessageRequestHandlerTest.cs
@@ -108,7 +108,7 @@ namespace Catalyst.Node.Core.UnitTests.RPC
             var sentResponse = (ProtocolMessage) receivedCalls.Single().GetArguments().Single();
             sentResponse.TypeUrl.Should().Be(VerifyMessageResponse.Descriptor.ShortenedFullName());
 
-            var responseContent = sentResponse.FromAnySigned<VerifyMessageResponse>();
+            var responseContent = sentResponse.FromProtocolMessage<VerifyMessageResponse>();
 
             responseContent.IsSignedByKey.Should().Be(expectedResult);
         }

--- a/src/Catalyst.Node.Core/Modules/Consensus/Delta/DeltaHub.cs
+++ b/src/Catalyst.Node.Core/Modules/Consensus/Delta/DeltaHub.cs
@@ -72,7 +72,7 @@ namespace Catalyst.Node.Core.Modules.Consensus.Delta
                 return;
             }
 
-            var protocolMessage = candidate.ToAnySigned(_peerIdentifier.PeerId, Guid.NewGuid());
+            var protocolMessage = candidate.ToProtocolMessage(_peerIdentifier.PeerId, Guid.NewGuid());
             _gossipManager.BroadcastAsync(null);
 
             _logger.Debug("Started gossiping candidate {0}", candidate);

--- a/src/Catalyst.Node.Core/P2P/Messaging/Gossip/GossipManager.cs
+++ b/src/Catalyst.Node.Core/P2P/Messaging/Gossip/GossipManager.cs
@@ -84,7 +84,7 @@ namespace Catalyst.Node.Core.P2P.Messaging.Gossip
         /// <inheritdoc/>
         public async Task BroadcastAsync(ProtocolMessage protocolMessage)
         {
-            if (protocolMessage.CheckIfMessageIsGossip())
+            if (protocolMessage.CheckIfMessageIsBroadcast())
             {
                 throw new NotSupportedException("Cannot broadcast a message which is already a gossip type");
             }
@@ -104,7 +104,7 @@ namespace Catalyst.Node.Core.P2P.Messaging.Gossip
         /// <inheritdoc/>
         public async Task ReceiveAsync(ProtocolMessage protocolMessage)
         {
-            if (!protocolMessage.CheckIfMessageIsGossip())
+            if (!protocolMessage.CheckIfMessageIsBroadcast())
             {
                 throw new NotSupportedException("The Message is not a gossip type");
             }

--- a/src/Catalyst.Node.Core/P2P/Messaging/Handlers/PingRequestHandler.cs
+++ b/src/Catalyst.Node.Core/P2P/Messaging/Handlers/PingRequestHandler.cs
@@ -50,7 +50,7 @@ namespace Catalyst.Node.Core.P2P.Messaging.Handlers
         protected override void Handler(IChanneledMessage<ProtocolMessage> message)
         {
             Logger.Information("Ping Message Received");
-            var deserialised = message.Payload.FromAnySigned<PingRequest>();
+            var deserialised = message.Payload.FromProtocolMessage<PingRequest>();
             Logger.Debug("message content is {0}", deserialised);
 
             var datagramEnvelope = new MessageFactory().GetDatagramMessage(new MessageDto(

--- a/src/Catalyst.Node.Core/P2P/Messaging/Handlers/PingResponseHandler.cs
+++ b/src/Catalyst.Node.Core/P2P/Messaging/Handlers/PingResponseHandler.cs
@@ -41,7 +41,7 @@ namespace Catalyst.Node.Core.P2P.Messaging.Handlers
         protected override void Handler(IChanneledMessage<ProtocolMessage> message)
         {
             Logger.Debug("received ping response");
-            var deserialised = message.Payload.FromAnySigned<PingResponse>();
+            var deserialised = message.Payload.FromProtocolMessage<PingResponse>();
         }
     }
 }

--- a/src/Catalyst.Node.Core/P2P/Messaging/Handlers/TransactionRequestHandler.cs
+++ b/src/Catalyst.Node.Core/P2P/Messaging/Handlers/TransactionRequestHandler.cs
@@ -41,7 +41,7 @@ namespace Catalyst.Node.Core.P2P.Messaging.Handlers
         protected override void Handler(IChanneledMessage<ProtocolMessage> message)
         {
             Logger.Debug("received pong");
-            var deserialised = message.Payload.FromAnySigned<TransactionBroadcast>();
+            var deserialised = message.Payload.FromProtocolMessage<TransactionBroadcast>();
             Logger.Debug("transaction pong is {0}", deserialised.Signature);
         }
     }

--- a/src/Catalyst.Node.Core/P2P/PeerDiscovery.cs
+++ b/src/Catalyst.Node.Core/P2P/PeerDiscovery.cs
@@ -109,7 +109,7 @@ namespace Catalyst.Node.Core.P2P
         private void PingSubscriptionHandler(IChanneledMessage<ProtocolMessage> message)
         {
             Logger.Information("processing ping message stream");
-            var pingResponse = message.Payload.FromAnySigned<PingResponse>();
+            var pingResponse = message.Payload.FromProtocolMessage<PingResponse>();
             PeerRepository.Add(new Peer
             {
                 LastSeen = DateTime.Now,
@@ -123,7 +123,7 @@ namespace Catalyst.Node.Core.P2P
         public void PeerNeighbourSubscriptionHandler(IChanneledMessage<ProtocolMessage> message)
         {
             Logger.Information("processing peer neighbour message stream");
-            var peerNeighborsResponse = message.Payload.FromAnySigned<PeerNeighborsResponse>();
+            var peerNeighborsResponse = message.Payload.FromProtocolMessage<PeerNeighborsResponse>();
         }
 
         private async Task PeerCrawler()

--- a/src/Catalyst.Node.Core/RPC/Handlers/AddFileToDfsRequestHandler.cs
+++ b/src/Catalyst.Node.Core/RPC/Handlers/AddFileToDfsRequestHandler.cs
@@ -84,7 +84,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
         /// <param name="message">The message.</param>
         protected override void Handler(IChanneledMessage<ProtocolMessage> message)
         {
-            var deserialised = message.Payload.FromAnySigned<AddFileToDfsRequest>();
+            var deserialised = message.Payload.FromProtocolMessage<AddFileToDfsRequest>();
 
             Guard.Argument(deserialised).NotNull("Message cannot be null");
             

--- a/src/Catalyst.Node.Core/RPC/Handlers/GetFileFromDfsRequestHandler.cs
+++ b/src/Catalyst.Node.Core/RPC/Handlers/GetFileFromDfsRequestHandler.cs
@@ -85,7 +85,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
         /// <param name="message">The message.</param>
         protected override void Handler(IChanneledMessage<ProtocolMessage> message)
         {
-            var deserialised = message.Payload.FromAnySigned<GetFileFromDfsRequest>();
+            var deserialised = message.Payload.FromProtocolMessage<GetFileFromDfsRequest>();
 
             Guard.Argument(deserialised).NotNull("Message cannot be null");
 

--- a/src/Catalyst.Node.Core/RPC/Handlers/GetInfoRequestHandler.cs
+++ b/src/Catalyst.Node.Core/RPC/Handlers/GetInfoRequestHandler.cs
@@ -64,7 +64,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
             Logger.Debug("received message of type GetInfoRequest");
             try
             {
-                var deserialised = message.Payload.FromAnySigned<GetInfoRequest>();
+                var deserialised = message.Payload.FromProtocolMessage<GetInfoRequest>();
                 
                 Guard.Argument(deserialised).NotNull();
                 

--- a/src/Catalyst.Node.Core/RPC/Handlers/GetMempoolRequestHandler.cs
+++ b/src/Catalyst.Node.Core/RPC/Handlers/GetMempoolRequestHandler.cs
@@ -66,7 +66,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
             
             try
             {
-                var deserialised = message.Payload.FromAnySigned<GetMempoolRequest>();
+                var deserialised = message.Payload.FromProtocolMessage<GetMempoolRequest>();
                 
                 Guard.Argument(deserialised).NotNull("The shell GetMempoolRequest cannot be null.");
                 

--- a/src/Catalyst.Node.Core/RPC/Handlers/PeerBlackListingRequestHandler.cs
+++ b/src/Catalyst.Node.Core/RPC/Handlers/PeerBlackListingRequestHandler.cs
@@ -67,7 +67,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
         {
             _message = message;
 
-            var deserialised = message.Payload.FromAnySigned<SetPeerBlackListRequest>();
+            var deserialised = message.Payload.FromProtocolMessage<SetPeerBlackListRequest>();
             var publicKey = deserialised.PublicKey.ToStringUtf8(); 
             var ip = deserialised.Ip.ToStringUtf8();
             var blackList = deserialised.Blacklist;
@@ -104,7 +104,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
                 PublicKey = publicKey
             };
 
-            var anySignedResponse = response.ToAnySigned(_peerId, _message.Payload.CorrelationId.ToGuid());
+            var anySignedResponse = response.ToProtocolMessage(_peerId, _message.Payload.CorrelationId.ToGuid());
 
             message.Context.Channel.WriteAndFlushAsync(anySignedResponse).GetAwaiter().GetResult();
         }

--- a/src/Catalyst.Node.Core/RPC/Handlers/PeerBlackListingResponseHandler.cs
+++ b/src/Catalyst.Node.Core/RPC/Handlers/PeerBlackListingResponseHandler.cs
@@ -67,7 +67,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
 
             try
             {
-                var deserialised = message.Payload.FromAnySigned<SetPeerBlackListResponse>();
+                var deserialised = message.Payload.FromProtocolMessage<SetPeerBlackListResponse>();
 
                 var msg = deserialised.PublicKey.ToStringUtf8() == string.Empty
                     ? "Peer not found"

--- a/src/Catalyst.Node.Core/RPC/Handlers/PeerReputationRequestHandler.cs
+++ b/src/Catalyst.Node.Core/RPC/Handlers/PeerReputationRequestHandler.cs
@@ -69,7 +69,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
 
             _message = message;
 
-            var deserialised = message.Payload.FromAnySigned<GetPeerReputationRequest>();
+            var deserialised = message.Payload.FromProtocolMessage<GetPeerReputationRequest>();
             var publicKey = deserialised.PublicKey.ToStringUtf8(); 
             var ip = deserialised.Ip.ToStringUtf8();
 
@@ -92,7 +92,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
                 Reputation = reputation
             };
 
-            var anySignedResponse = response.ToAnySigned(_peerId, _message.Payload.CorrelationId.ToGuid());
+            var anySignedResponse = response.ToProtocolMessage(_peerId, _message.Payload.CorrelationId.ToGuid());
 
             message.Context.Channel.WriteAndFlushAsync(anySignedResponse).GetAwaiter().GetResult();
         }

--- a/src/Catalyst.Node.Core/RPC/Handlers/RemovePeerRequestHandler.cs
+++ b/src/Catalyst.Node.Core/RPC/Handlers/RemovePeerRequestHandler.cs
@@ -82,7 +82,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
             {
                 UInt32 peerDeletedCount = 0;
 
-                var deserialised = message.Payload.FromAnySigned<RemovePeerRequest>();
+                var deserialised = message.Payload.FromProtocolMessage<RemovePeerRequest>();
                 var publicKeyIsEmpty = deserialised.PublicKey.IsEmpty;
 
                 Guard.Argument(deserialised).NotNull();

--- a/src/Catalyst.Node.Core/RPC/Handlers/SignMessageRequestHandler.cs
+++ b/src/Catalyst.Node.Core/RPC/Handlers/SignMessageRequestHandler.cs
@@ -66,7 +66,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
 
             try
             {
-                var deserialised = message.Payload.FromAnySigned<SignMessageRequest>();
+                var deserialised = message.Payload.FromProtocolMessage<SignMessageRequest>();
 
                 Guard.Argument(message).NotNull("The request cannot be null");
 

--- a/src/Catalyst.Node.Core/RPC/Handlers/TransferFileBytesRequestHandler.cs
+++ b/src/Catalyst.Node.Core/RPC/Handlers/TransferFileBytesRequestHandler.cs
@@ -71,7 +71,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
         /// <param name="message">The message.</param>
         protected override void Handler(IChanneledMessage<ProtocolMessage> message)
         {
-            var deserialised = message.Payload.FromAnySigned<TransferFileBytesRequest>();
+            var deserialised = message.Payload.FromProtocolMessage<TransferFileBytesRequest>();
             FileTransferResponseCodes responseCode;
             try
             {

--- a/src/Catalyst.Node.Core/RPC/Handlers/VerifyMessageRequestHandler.cs
+++ b/src/Catalyst.Node.Core/RPC/Handlers/VerifyMessageRequestHandler.cs
@@ -72,7 +72,7 @@ namespace Catalyst.Node.Core.RPC.Handlers
             
             Logger.Debug("received message of type VerifyMessageRequest");
             
-            var deserialised = message.Payload.FromAnySigned<VerifyMessageRequest>();
+            var deserialised = message.Payload.FromProtocolMessage<VerifyMessageRequest>();
             Guard.Argument(deserialised).NotNull("The verify message request cannot be null");
 
             var decodedMessage = RLP.Decode(deserialised.Message.ToByteArray()).RLPData.ToStringFromRLPDecoded();

--- a/src/Catalyst.Node.Rpc.Client.IntegrationTests/Handlers/GetFileFromDfsResponseHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client.IntegrationTests/Handlers/GetFileFromDfsResponseHandler.cs
@@ -114,7 +114,7 @@ namespace Catalyst.Node.Rpc.Client.IntegrationTests.Handlers
                 {
                     FileSize = (ulong) byteSize,
                     ResponseCode = ByteString.CopyFrom((byte) FileTransferResponseCodes.Successful.Id)
-                }.ToAnySigned(nodePeer.PeerId, correlationGuid);
+                }.ToProtocolMessage(nodePeer.PeerId, correlationGuid);
 
                 getFileResponse.SendToHandler(_fakeContext, getFileFromDfsResponseHandler);
 

--- a/src/Catalyst.Node.Rpc.Client.UnitTests/Handlers/AddFileToDfsResponseHandlerTests.cs
+++ b/src/Catalyst.Node.Rpc.Client.UnitTests/Handlers/AddFileToDfsResponseHandlerTests.cs
@@ -94,7 +94,7 @@ namespace Catalyst.Node.Rpc.Client.UnitTests.Handlers
                 ResponseCode = ByteString.CopyFrom((byte) responseCode)
             };
 
-            var protocolMessage = addFileResponse.ToAnySigned(PeerIdHelper.GetPeerId("Test"), Guid.NewGuid());
+            var protocolMessage = addFileResponse.ToProtocolMessage(PeerIdHelper.GetPeerId("Test"), Guid.NewGuid());
             return new ProtocolMessageDto(_channelHandlerContext, protocolMessage);
         }
     }

--- a/src/Catalyst.Node.Rpc.Client.UnitTests/Handlers/GetFileFromDfsResponseHandlerTest.cs
+++ b/src/Catalyst.Node.Rpc.Client.UnitTests/Handlers/GetFileFromDfsResponseHandlerTest.cs
@@ -76,7 +76,7 @@ namespace Catalyst.Node.Rpc.Client.UnitTests.Handlers
             {
                 FileSize = 10,
                 ResponseCode = ByteString.CopyFrom((byte) FileTransferResponseCodes.Error.Id)
-            }.ToAnySigned(PeerIdHelper.GetPeerId("Test"), guid);
+            }.ToProtocolMessage(PeerIdHelper.GetPeerId("Test"), guid);
             getFileResponse.SendToHandler(_fakeContext, getFileFromDfsResponseHandler);
 
             fakeFileTransfer.Received(1).Expire();

--- a/src/Catalyst.Node.Rpc.Client/Handlers/AddFileToDfsResponseHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client/Handlers/AddFileToDfsResponseHandler.cs
@@ -64,7 +64,7 @@ namespace Catalyst.Node.Rpc.Client.Handlers
         /// <param name="message">The message.</param>
         protected override void Handler(IChanneledMessage<ProtocolMessage> message)
         {
-            var deserialised = message.Payload.FromAnySigned<AddFileToDfsResponse>();
+            var deserialised = message.Payload.FromProtocolMessage<AddFileToDfsResponse>();
 
             Guard.Argument(deserialised).NotNull("Message cannot be null");
 

--- a/src/Catalyst.Node.Rpc.Client/Handlers/GetFileFromDfsResponseHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client/Handlers/GetFileFromDfsResponseHandler.cs
@@ -59,7 +59,7 @@ namespace Catalyst.Node.Rpc.Client.Handlers
         /// <param name="message">The message.</param>
         protected override void Handler(IChanneledMessage<ProtocolMessage> message)
         {
-            var deserialised = message.Payload.FromAnySigned<GetFileFromDfsResponse>();
+            var deserialised = message.Payload.FromProtocolMessage<GetFileFromDfsResponse>();
 
             Guard.Argument(deserialised).NotNull("Message cannot be null");
 

--- a/src/Catalyst.Node.Rpc.Client/Handlers/GetInfoResponseHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client/Handlers/GetInfoResponseHandler.cs
@@ -68,7 +68,7 @@ namespace Catalyst.Node.Rpc.Client.Handlers
             
             try
             {
-                var deserialised = message.Payload.FromAnySigned<GetInfoResponse>();
+                var deserialised = message.Payload.FromProtocolMessage<GetInfoResponse>();
                 
                 Guard.Argument(deserialised).NotNull().Require(d => d.Query != null, d => $"{nameof(deserialised)} must have a valid configuration response.");
                 

--- a/src/Catalyst.Node.Rpc.Client/Handlers/GetMempoolResponseHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client/Handlers/GetMempoolResponseHandler.cs
@@ -71,7 +71,7 @@ namespace Catalyst.Node.Rpc.Client.Handlers
             
             try
             {
-                var deserialised = message.Payload.FromAnySigned<GetMempoolResponse>();
+                var deserialised = message.Payload.FromProtocolMessage<GetMempoolResponse>();
                 
                 Guard.Argument(deserialised, nameof(deserialised)).NotNull("The GetMempoolResponse cannot be null")
                    .Require(d => d.Mempool != null,

--- a/src/Catalyst.Node.Rpc.Client/Handlers/GetVersionResponseHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client/Handlers/GetVersionResponseHandler.cs
@@ -64,7 +64,7 @@ namespace Catalyst.Node.Rpc.Client.Handlers
             
             try
             {
-                var deserialised = message.Payload.FromAnySigned<VersionResponse>();
+                var deserialised = message.Payload.FromProtocolMessage<VersionResponse>();
                 
                 Guard.Argument(deserialised, nameof(deserialised)).NotNull("The VersionResponse cannot be null")
                    .Require(d => d.Version != null,

--- a/src/Catalyst.Node.Rpc.Client/Handlers/PeerCountResponseHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client/Handlers/PeerCountResponseHandler.cs
@@ -67,7 +67,7 @@ namespace Catalyst.Node.Rpc.Client.Handlers
 
             try
             {
-                var deserialised = message.Payload.FromAnySigned<GetPeerCountResponse>();
+                var deserialised = message.Payload.FromProtocolMessage<GetPeerCountResponse>();
                 _output.WriteLine("Peer count: " + deserialised.PeerCount.ToString());
             }
             catch (Exception ex)

--- a/src/Catalyst.Node.Rpc.Client/Handlers/PeerListResponseHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client/Handlers/PeerListResponseHandler.cs
@@ -67,7 +67,7 @@ namespace Catalyst.Node.Rpc.Client.Handlers
 
             try
             {
-                var deserialised = message.Payload.FromAnySigned<GetPeerListResponse>();
+                var deserialised = message.Payload.FromProtocolMessage<GetPeerListResponse>();
                 var result = string.Join(", ", deserialised.Peers);
                 _output.WriteLine(result);
             }

--- a/src/Catalyst.Node.Rpc.Client/Handlers/PeerReputationResponseHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client/Handlers/PeerReputationResponseHandler.cs
@@ -67,7 +67,7 @@ namespace Catalyst.Node.Rpc.Client.Handlers
 
             try
             {
-                var deserialised = message.Payload.FromAnySigned<GetPeerReputationResponse>();
+                var deserialised = message.Payload.FromProtocolMessage<GetPeerReputationResponse>();
                 var msg = deserialised.Reputation == int.MinValue ? "Peer not found" : deserialised.Reputation.ToString();
                 _output.WriteLine("Peer Reputation: " + msg);
             }

--- a/src/Catalyst.Node.Rpc.Client/Handlers/RemovePeerResponseHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client/Handlers/RemovePeerResponseHandler.cs
@@ -64,7 +64,7 @@ namespace Catalyst.Node.Rpc.Client.Handlers
 
             try
             {
-                var deserialised = message.Payload.FromAnySigned<RemovePeerResponse>();
+                var deserialised = message.Payload.FromProtocolMessage<RemovePeerResponse>();
                 var deletedCount = deserialised.DeletedCount;
 
                 _userOutput.WriteLine($"Deleted {deletedCount.ToString()} peers");

--- a/src/Catalyst.Node.Rpc.Client/Handlers/SignMessageResponseHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client/Handlers/SignMessageResponseHandler.cs
@@ -65,7 +65,7 @@ namespace Catalyst.Node.Rpc.Client.Handlers
         {
             try
             {
-                var deserialised = message.Payload.FromAnySigned<SignMessageResponse>();
+                var deserialised = message.Payload.FromProtocolMessage<SignMessageResponse>();
 
                 var decodeResult = RLP.Decode(deserialised.OriginalMessage.ToByteArray()).RLPData;
 

--- a/src/Catalyst.Node.Rpc.Client/Handlers/TransferFileBytesRequestHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client/Handlers/TransferFileBytesRequestHandler.cs
@@ -89,7 +89,7 @@ namespace Catalyst.Node.Rpc.Client.Handlers
         /// <param name="message">The message.</param>
         protected override void Handler(IChanneledMessage<ProtocolMessage> message)
         {
-            var deserialised = message.Payload.FromAnySigned<TransferFileBytesRequest>();
+            var deserialised = message.Payload.FromProtocolMessage<TransferFileBytesRequest>();
             FileTransferResponseCodes responseCode;
 
             try

--- a/src/Catalyst.Node.Rpc.Client/Handlers/VerifyMessageResponseHandler.cs
+++ b/src/Catalyst.Node.Rpc.Client/Handlers/VerifyMessageResponseHandler.cs
@@ -66,7 +66,7 @@ namespace Catalyst.Node.Rpc.Client.Handlers
 
             try
             {
-                var deserialised = message.Payload.FromAnySigned<VerifyMessageResponse>();
+                var deserialised = message.Payload.FromProtocolMessage<VerifyMessageResponse>();
                 Guard.Argument(deserialised).NotNull("The verify message response cannot be null");
 
                 //decode the received message

--- a/src/Catalyst.TestUtils/TestMessageHandler.cs
+++ b/src/Catalyst.TestUtils/TestMessageHandler.cs
@@ -46,7 +46,7 @@ namespace Catalyst.TestUtils
         
         protected override void Handler(IChanneledMessage<ProtocolMessage> message)
         {
-            SubstituteObserver.OnNext(message.Payload.FromAnySigned<TProto>());
+            SubstituteObserver.OnNext(message.Payload.FromProtocolMessage<TProto>());
         }
 
         public override void HandleError(Exception exception) { SubstituteObserver.OnError(exception); }


### PR DESCRIPTION
### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [ ] I have added tests to cover my changes.
4. [ ] All new and existing tests passed.
5. [x] Have you lint your code locally prior to submission?
6. [x] Does your code follows the code style of this project?
7. [ ] Does your change require a change to the documentation.
    - [ ] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [ ] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [ ] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

We updated naming convention of AnySigned to ProtocolMessage/ProtocolMessageSigned. This updates the protobufs extension helpers to follow suit 
* **What is the current behavior?** (You can also link to an open issue here)

* **What is the new behavior (if this is a feature change)?**

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
