### PR TITLE
#522 Update Broadcast to not use GetAll()

### DIFF
--- a/src/Catalyst.Node.Core.UnitTests/P2P/Messaging/Gossip/GossipManagerTests.cs
+++ b/src/Catalyst.Node.Core.UnitTests/P2P/Messaging/Gossip/GossipManagerTests.cs
@@ -236,6 +236,7 @@ namespace Catalyst.Node.Core.UnitTests.P2P.Messaging.Gossip
         public void Dispose()
         {
             _cache.Dispose();
+            _peers.Dispose();
         }
     }
 }

--- a/src/Catalyst.Node.Core/P2P/Messaging/Broadcast/BroadcastManager.cs
+++ b/src/Catalyst.Node.Core/P2P/Messaging/Broadcast/BroadcastManager.cs
@@ -153,7 +153,7 @@ namespace Catalyst.Node.Core.P2P.Messaging.Broadcast
         {
             return _peers
                .AsQueryable()
-               .Select(c => c.PkId).Shuffle().Select(_peers.Get).Take(count).Select(p => p.PeerIdentifier).ToList();
+               .Select(c => c.PkId).Shuffle().Take(count).Select(_peers.Get).Select(p => p.PeerIdentifier).ToList();
         }
 
         /// <summary>Determines whether this instance can gossip the specified correlation identifier.</summary>
@@ -178,7 +178,7 @@ namespace Catalyst.Node.Core.P2P.Messaging.Broadcast
         private uint GetMaxGossipCycles(BroadcastMessage broadcastMessage)
         {
             var peerNetworkSize = broadcastMessage.PeerNetworkSize;
-            return (uint)(Math.Log(Math.Max(10, peerNetworkSize) / (double) Constants.MaxGossipPeersPerRound) /
+            return (uint) (Math.Log(Math.Max(10, peerNetworkSize) / (double) Constants.MaxGossipPeersPerRound) /
                 Math.Max(1, broadcastMessage.GossipCount / Constants.MaxGossipPeersPerRound));
         }
 


### PR DESCRIPTION
### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [x] I have added tests to cover my changes.
4. [x] All new and existing tests passed.
5. [x] Have you lint your code locally prior to submission?
6. [x] Does your code follows the code style of this project?
7. [ ] Does your change require a change to the documentation.
    - [ ] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [x] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [x] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Stop the use of GetAll on the peer repository

* **What is the current behavior?** (You can also link to an open issue here)
GetAll is used

* **What is the new behavior (if this is a feature change)?**
Only all the indexes are gathered now then shuffled and taken

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
