### PR TITLE
#521 Fix CanHandlerDownloadChunk test

### DIFF
--- a/src/Catalyst.Node.Core.UnitTests/RPC/Observables/TransferFileBytesRequestObserverTest.cs
+++ b/src/Catalyst.Node.Core.UnitTests/RPC/Observables/TransferFileBytesRequestObserverTest.cs
@@ -49,7 +49,6 @@ namespace Catalyst.Node.Core.UnitTests.RPC.Observables
         private readonly TransferFileBytesRequestObserver _observer;
         private readonly IDownloadFileTransferFactory _downloadFileTransferFactory;
         private readonly IChannelHandlerContext _context;
-        private readonly ILogger _logger;
 
         public TransferFileBytesRequestObserverTest()
         {
@@ -57,14 +56,12 @@ namespace Catalyst.Node.Core.UnitTests.RPC.Observables
             _context.Channel.Returns(Substitute.For<IChannel>());
             _downloadFileTransferFactory = Substitute.For<IDownloadFileTransferFactory>();
             var peerIdentifier = PeerIdentifierHelper.GetPeerIdentifier("Test");
-            _logger = Substitute.For<ILogger>();
-
             _observer = new TransferFileBytesRequestObserver(_downloadFileTransferFactory,
                 peerIdentifier,
                 Substitute.For<ILogger>());
         }
 
-        [Fact(Skip = "This tests needs to mock downloadChunk() return correctly")]
+        [Fact]
         public void CanHandlerDownloadChunk()
         {
             var guid = Guid.NewGuid();
@@ -74,8 +71,11 @@ namespace Catalyst.Node.Core.UnitTests.RPC.Observables
                 ChunkId = 1,
                 CorrelationFileName = Guid.NewGuid().ToByteString()
             }.ToProtocolMessage(PeerIdHelper.GetPeerId("Test"), guid);
-            request.SendToHandler(_context, _observer);
 
+            _downloadFileTransferFactory.DownloadChunk(Arg.Any<Guid>(), Arg.Any<uint>(), Arg.Any<byte[]>())
+               .Returns(FileTransferResponseCodes.Successful);
+
+            request.SendToHandler(_context, _observer);
             _downloadFileTransferFactory.Received(1).DownloadChunk(Arg.Any<Guid>(), Arg.Any<uint>(), Arg.Any<byte[]>());
         }
 


### PR DESCRIPTION
### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [x] I have added tests to cover my changes.
4. [x] All new and existing tests passed.
5. [x] Have you lint your code locally prior to submission?
6. [x] Does your code follows the code style of this project?
7. [x] Does your change require a change to the documentation.
    - [x] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [x] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [x] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix CanHandlerDownloadChunk unit test

* **What is the current behavior?** (You can also link to an open issue here)
Failing due the the download factory not being mocked correctly

* **What is the new behavior (if this is a feature change)?**
The download factory is now returning the response code 'Success' when download is called

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
* **Other information**:
