### PR TITLE
#513 ToAnySigned_should_fail_on_response_without_correlationId

### DIFF
--- a/src/Catalyst.Common.UnitTests/Extensions/ProtobufExtensionsTests.cs
+++ b/src/Catalyst.Common.UnitTests/Extensions/ProtobufExtensionsTests.cs
@@ -25,6 +25,7 @@ using System;
 using Catalyst.Common.Extensions;
 using Catalyst.Protocol.Common;
 using Catalyst.Protocol.IPPN;
+using Catalyst.Protocol.Rpc.Node;
 using Catalyst.Protocol.Transaction;
 using Catalyst.TestUtils;
 using FluentAssertions;
@@ -92,15 +93,23 @@ namespace Catalyst.Common.UnitTests.Extensions
         }
 
         [Fact]
-        public static void ToProtocolMessage_Should_Generate_New_CorrelationId_If_Not_Specified()
+        public static void ToProtocolMessage_When_Processing_Request_Should_Generate_New_CorrelationId_If_Not_Specified()
         {
             var peerId = PeerIdHelper.GetPeerId("someone");
-            var expectedContent = "censored";
-            var response = new PeerId
+            var request = new GetPeerCountRequest().ToProtocolMessage(peerId);
+            request.CorrelationId.ToGuid().Should().NotBe(default);
+        }
+
+        [Fact]
+        public static void ToProtocolMessage_When_Processing_Request_Should_Fail_If_No_CorrelationId_Specified()
+        {
+            var peerId = PeerIdHelper.GetPeerId("someone");
+            var response = new GetPeerCountResponse
             {
-                ClientId = expectedContent.ToUtf8ByteString()
-            }.ToProtocolMessage(peerId);
-            response.CorrelationId.ToGuid().Should().NotBe(default);
+                PeerCount = 13
+            };
+            new Action(() => response.ToProtocolMessage(peerId))
+               .Should().Throw<ArgumentException>();
         }
 
         [Fact]


### PR DESCRIPTION
### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [x] I have added tests to cover my changes.
4. [x] All new and existing tests passed.
5. [x] Have you lint your code locally prior to submission?
6. [x] Does your code follows the code style of this project?
7. [ ] Does your change require a change to the documentation.
    - [ ] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [x] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [x] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
ToAnySigned_should_fail_on_response_without_correlationId test is invalid. Now when no correlation ID is specified ToProtocolMessage generates a new GUID.

* **What is the current behavior?** (You can also link to an open issue here)
The test checks for an exception when no correlation ID is specified and the ToProtocolMessage is called

* **What is the new behavior (if this is a feature change)?**
The test will now check if a new GUID has been generated if no GUID is specified

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
