### PR TITLE
put cli int test container into llifetime scope

### DIFF
--- a/src/Catalyst.Cli.IntegrationTests/Commands/ConnectNodeTest.cs
+++ b/src/Catalyst.Cli.IntegrationTests/Commands/ConnectNodeTest.cs
@@ -21,7 +21,6 @@
 
 #endregion
 
-using System;
 using Autofac;
 using Catalyst.Common.Interfaces.Cli;
 using FluentAssertions;

--- a/src/Catalyst.Cli.IntegrationTests/Commands/GetFileCommandTest.cs
+++ b/src/Catalyst.Cli.IntegrationTests/Commands/GetFileCommandTest.cs
@@ -48,34 +48,35 @@ namespace Catalyst.Cli.IntegrationTests.Commands
         [MemberData(nameof(GetFileData))]
         public async Task Cli_Can_Send_Get_File_Request(string fileHash, string outputPath, bool expectedResult)
         {
-            var container = ContainerBuilder.Build();
-
-            using (container.BeginLifetimeScope(CurrentTestName))
+            using (var container = ContainerBuilder.Build())
             {
-                var shell = container.Resolve<ICatalystCli>();
-                var downloadFileFactory = container.Resolve<IDownloadFileTransferFactory>();
-
-                var hasConnected = shell.AdvancedShell.ParseCommand("connect", "-n", "node1");
-                hasConnected.Should().BeTrue();
-
-                var node1 = shell.AdvancedShell.GetConnectedNode("node1");
-                node1.Should().NotBeNull("we've just connected it");
-
-                var task = Task.Run(() =>
-                    shell.AdvancedShell.ParseCommand("getfile", "-n", "node1", "-f", fileHash, "-o", outputPath)
-                );
-
-                await TaskHelper.WaitForAsync(() => downloadFileFactory.Keys.Length > 0, TimeSpan.FromSeconds(5));
-
-                downloadFileFactory.GetFileTransferInformation(downloadFileFactory.Keys.First()).Expire();
-
-                var result = await task.ConfigureAwait(false);
-                result.Should().Be(expectedResult);
-
-                if (expectedResult)
+                using (container.BeginLifetimeScope(CurrentTestName))
                 {
-                    NodeRpcClient.Received(1).SendMessage(Arg.Is<ProtocolMessage>(x =>
-                        x.TypeUrl.Equals(GetFileFromDfsRequest.Descriptor.ShortenedFullName())));
+                    var shell = container.Resolve<ICatalystCli>();
+                    var downloadFileFactory = container.Resolve<IDownloadFileTransferFactory>();
+
+                    var hasConnected = shell.AdvancedShell.ParseCommand("connect", "-n", "node1");
+                    hasConnected.Should().BeTrue();
+
+                    var node1 = shell.AdvancedShell.GetConnectedNode("node1");
+                    node1.Should().NotBeNull("we've just connected it");
+
+                    var task = Task.Run(() =>
+                        shell.AdvancedShell.ParseCommand("getfile", "-n", "node1", "-f", fileHash, "-o", outputPath)
+                    );
+
+                    await TaskHelper.WaitForAsync(() => downloadFileFactory.Keys.Length > 0, TimeSpan.FromSeconds(5));
+
+                    downloadFileFactory.GetFileTransferInformation(downloadFileFactory.Keys.First()).Expire();
+
+                    var result = await task.ConfigureAwait(false);
+                    result.Should().Be(expectedResult);
+
+                    if (expectedResult)
+                    {
+                        NodeRpcClient.Received(1).SendMessage(Arg.Is<ProtocolMessage>(x =>
+                            x.TypeUrl.Equals(GetFileFromDfsRequest.Descriptor.ShortenedFullName())));
+                    }
                 }
             }
         }

--- a/src/Catalyst.Cli.IntegrationTests/Commands/GetInfoCommandTest.cs
+++ b/src/Catalyst.Cli.IntegrationTests/Commands/GetInfoCommandTest.cs
@@ -21,7 +21,6 @@
 
 #endregion
 
-using System;
 using Autofac;
 using Catalyst.Common.Interfaces.Cli;
 using FluentAssertions;

--- a/src/Catalyst.Cli.IntegrationTests/Commands/GetMempoolTest.cs
+++ b/src/Catalyst.Cli.IntegrationTests/Commands/GetMempoolTest.cs
@@ -21,7 +21,6 @@
 
 #endregion
 
-using System;
 using Autofac;
 using Catalyst.Common.Interfaces.Cli;
 using FluentAssertions;

--- a/src/Catalyst.Cli.IntegrationTests/Commands/GetVersionCommandTest.cs
+++ b/src/Catalyst.Cli.IntegrationTests/Commands/GetVersionCommandTest.cs
@@ -21,7 +21,6 @@
 
 #endregion
 
-using System;
 using Autofac;
 using Catalyst.Common.Interfaces.Cli;
 using FluentAssertions;

--- a/src/Catalyst.Cli.IntegrationTests/Commands/PeerListCommandTest.cs
+++ b/src/Catalyst.Cli.IntegrationTests/Commands/PeerListCommandTest.cs
@@ -21,7 +21,6 @@
 
 #endregion
 
-using System;
 using Autofac;
 using Catalyst.Common.Extensions;
 using Catalyst.Common.Interfaces.Cli;
@@ -43,21 +42,22 @@ namespace Catalyst.Cli.IntegrationTests.Commands
         [Fact] 
         public void Cli_Can_Send_List_Peers_Request()
         {
-            var container = ContainerBuilder.Build();
-
-            using (container.BeginLifetimeScope(CurrentTestName))
+            using (var container = ContainerBuilder.Build())
             {
-                var shell = container.Resolve<ICatalystCli>();
-                var hasConnected = shell.AdvancedShell.ParseCommand("connect", "-n", "node1");
-                hasConnected.Should().BeTrue();
+                using (container.BeginLifetimeScope(CurrentTestName))
+                {
+                    var shell = container.Resolve<ICatalystCli>();
+                    var hasConnected = shell.AdvancedShell.ParseCommand("connect", "-n", "node1");
+                    hasConnected.Should().BeTrue();
 
-                var node1 = shell.AdvancedShell.GetConnectedNode("node1");
-                node1.Should().NotBeNull("we've just connected it");
+                    var node1 = shell.AdvancedShell.GetConnectedNode("node1");
+                    node1.Should().NotBeNull("we've just connected it");
 
-                var result = shell.AdvancedShell.ParseCommand(
-                    "listpeers", "-n", "node1");
-                result.Should().BeTrue();
-                NodeRpcClient.Received(1).SendMessage(Arg.Is<ProtocolMessage>(x => x.TypeUrl.Equals(GetPeerListRequest.Descriptor.ShortenedFullName())));
+                    var result = shell.AdvancedShell.ParseCommand(
+                        "listpeers", "-n", "node1");
+                    result.Should().BeTrue();
+                    NodeRpcClient.Received(1).SendMessage(Arg.Is<ProtocolMessage>(x => x.TypeUrl.Equals(GetPeerListRequest.Descriptor.ShortenedFullName())));
+                }
             }
         }
     }

--- a/src/Catalyst.Cli.IntegrationTests/Commands/PeerRemoveCommandTest.cs
+++ b/src/Catalyst.Cli.IntegrationTests/Commands/PeerRemoveCommandTest.cs
@@ -21,7 +21,6 @@
 
 #endregion
 
-using System;
 using Autofac;
 using Catalyst.Common.Extensions;
 using Catalyst.Common.Interfaces.Cli;
@@ -43,21 +42,22 @@ namespace Catalyst.Cli.IntegrationTests.Commands
         [Fact] 
         public void Cli_Can_Send_Remove_Peer_Request()
         {
-            var container = ContainerBuilder.Build();
-
-            using (container.BeginLifetimeScope(CurrentTestName))
+            using (var container = ContainerBuilder.Build())
             {
-                var shell = container.Resolve<ICatalystCli>();
-                var hasConnected = shell.AdvancedShell.ParseCommand("connect", "-n", "node1");
-                hasConnected.Should().BeTrue();
+                using (container.BeginLifetimeScope(CurrentTestName))
+                {
+                    var shell = container.Resolve<ICatalystCli>();
+                    var hasConnected = shell.AdvancedShell.ParseCommand("connect", "-n", "node1");
+                    hasConnected.Should().BeTrue();
 
-                var node1 = shell.AdvancedShell.GetConnectedNode("node1");
-                node1.Should().NotBeNull("we've just connected it");
+                    var node1 = shell.AdvancedShell.GetConnectedNode("node1");
+                    node1.Should().NotBeNull("we've just connected it");
 
-                var result = shell.AdvancedShell.ParseCommand(
-                    "removepeer", "-n", "node1", "-k", "fake_public_key", "-i", "127.0.0.1");
-                result.Should().BeTrue();
-                NodeRpcClient.Received(1).SendMessage(Arg.Is<ProtocolMessage>(x => x.TypeUrl.Equals(RemovePeerRequest.Descriptor.ShortenedFullName())));
+                    var result = shell.AdvancedShell.ParseCommand(
+                        "removepeer", "-n", "node1", "-k", "fake_public_key", "-i", "127.0.0.1");
+                    result.Should().BeTrue();
+                    NodeRpcClient.Received(1).SendMessage(Arg.Is<ProtocolMessage>(x => x.TypeUrl.Equals(RemovePeerRequest.Descriptor.ShortenedFullName())));
+                }
             }
         }
     }

--- a/src/Catalyst.Cli.IntegrationTests/Commands/PeerReputationCommandTest.cs
+++ b/src/Catalyst.Cli.IntegrationTests/Commands/PeerReputationCommandTest.cs
@@ -21,7 +21,6 @@
 
 #endregion
 
-using System;
 using Autofac;
 using Catalyst.Common.Extensions;
 using Catalyst.Common.Interfaces.Cli;
@@ -43,21 +42,22 @@ namespace Catalyst.Cli.IntegrationTests.Commands
         [Fact] 
         public void Cli_Can_Send_Peer_Reputation_Request()
         {
-            var container = ContainerBuilder.Build();
-
-            using (container.BeginLifetimeScope(CurrentTestName))
+            using (var container = ContainerBuilder.Build())
             {
-                var shell = container.Resolve<ICatalystCli>();
-                var hasConnected = shell.AdvancedShell.ParseCommand("connect", "-n", "node1");
-                hasConnected.Should().BeTrue();
+                using (container.BeginLifetimeScope(CurrentTestName))
+                {
+                    var shell = container.Resolve<ICatalystCli>();
+                    var hasConnected = shell.AdvancedShell.ParseCommand("connect", "-n", "node1");
+                    hasConnected.Should().BeTrue();
 
-                var node1 = shell.AdvancedShell.GetConnectedNode("node1");
-                node1.Should().NotBeNull("we've just connected it");
+                    var node1 = shell.AdvancedShell.GetConnectedNode("node1");
+                    node1.Should().NotBeNull("we've just connected it");
 
-                var result = shell.AdvancedShell.ParseCommand(
-                    "peerrep", "-n", "node1", "-l", "127.0.0.1", "-p", "fake_public_key");
-                result.Should().BeTrue();
-                NodeRpcClient.Received(1).SendMessage(Arg.Is<ProtocolMessage>(x => x.TypeUrl.Equals(GetPeerReputationRequest.Descriptor.ShortenedFullName())));
+                    var result = shell.AdvancedShell.ParseCommand(
+                        "peerrep", "-n", "node1", "-l", "127.0.0.1", "-p", "fake_public_key");
+                    result.Should().BeTrue();
+                    NodeRpcClient.Received(1).SendMessage(Arg.Is<ProtocolMessage>(x => x.TypeUrl.Equals(GetPeerReputationRequest.Descriptor.ShortenedFullName())));
+                }
             }
         }
     }


### PR DESCRIPTION
### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [x] I have added tests to cover my changes.
4. [x] All new and existing tests passed.
5. [x] Have you lint your code locally prior to submission?
6. [x] Does your code follows the code style of this project?
7. [ ] Does your change require a change to the documentation.
    - [ ] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [x] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [x] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

puts the container in cli integration tests into a using statement

* **What is the current behavior?** (You can also link to an open issue here)

the container is not in a using statement.

* **What is the new behavior (if this is a feature change)?**

the container is in a using statement.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
