### PR TITLE
#605 Update PeerId to use assembly information such as version numbers fro…

### DIFF
--- a/src/Catalyst.Common/P2P/PeerIdClientId.cs
+++ b/src/Catalyst.Common/P2P/PeerIdClientId.cs
@@ -31,7 +31,7 @@ namespace Catalyst.Common.P2P
     {
         public PeerIdClientId(string clientVersion)
         {
-            var assemblyMajorVersion2Digits = Assembly.GetExecutingAssembly().GetName().Version.Major.ToString("D2");
+            var assemblyMajorVersion2Digits = Assembly.GetEntryAssembly().GetName().Version.Major.ToString("D2");
             AssemblyMajorVersion = Encoding.UTF8.GetBytes(assemblyMajorVersion2Digits);
             ClientVersion = Encoding.UTF8.GetBytes(clientVersion);
         }


### PR DESCRIPTION
…m the exe(Node) instead of lib(Common)

### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [x] I have added tests to cover my changes.
4. [x] All new and existing tests passed.
5. [x] Have you lint your code locally prior to submission?
6. [x] Does your code follows the code style of this project?
7. [x] Does your change require a change to the documentation.
    - [ ] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [x] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [x] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Assembly info for PeerId Version being pulled from library(Common) instead of entry exe(Node)

* **What is the new behavior (if this is a feature change)?**
Assembly info for PeerId Version is now pulled from entry exe(Node)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
closes #605 