### PR TITLE
Update ApiModule to use StaticFiles and DefaultFiles

### DIFF
--- a/src/Catalyst.Core/Api/ApiModule.cs
+++ b/src/Catalyst.Core/Api/ApiModule.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
@@ -30,6 +31,7 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Serilog;
 using Swashbuckle.AspNetCore.Swagger;
 using Module = Autofac.Module;
@@ -109,6 +111,12 @@ namespace Catalyst.Core.Api
             app.ApplicationServices = new AutofacServiceProvider(_container);
             app.UseDeveloperExceptionPage();
             app.UseCors(options => options.AllowAnyOrigin());
+            app.UseDefaultFiles();
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                FileProvider = new PhysicalFileProvider(
+                    Path.Combine(Directory.GetCurrentDirectory(), "wwwroot"))
+            });
             app.UseMvc(routes =>
             {
                 routes.MapRoute(name: "CatalystApi", template: "api/{controller}/{action}/{id}");


### PR DESCRIPTION
### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [x] I have added tests to cover my changes.
4. [x] All new and existing tests passed.
5. [x] Have you lint your code locally prior to submission?
6. [x] Does your code follows the code style of this project?
7. [x] Does your change require a change to the documentation.
    - [ ] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [x] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [x] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature to ApiModule
* **What is the current behavior?** (You can also link to an open issue here)
Cannot use StaticFiles or DefaultFiles eg / doesn't point to index.*
* **What is the new behavior (if this is a feature change)?**
Can do the above
* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
* **Other information**:
ApiModule does what the name implies, it serves Api controllers it maybe needs a rename or create another module that shares kestrel for this feature.