### PR TITLE
small test fixes and make RpcServer optional

### DIFF
--- a/src/Catalyst.Core.Modules.Rpc.Server/RpcServerModule.cs
+++ b/src/Catalyst.Core.Modules.Rpc.Server/RpcServerModule.cs
@@ -21,10 +21,12 @@
 
 #endregion
 
+using System;
 using Autofac;
 using Catalyst.Abstractions.IO.Transport.Channels;
 using Catalyst.Abstractions.Rpc;
 using Catalyst.Core.Modules.Rpc.Server.Transport.Channels;
+using Serilog;
 
 namespace Catalyst.Core.Modules.Rpc.Server
 {
@@ -35,6 +37,22 @@ namespace Catalyst.Core.Modules.Rpc.Server
             builder.RegisterType<RpcServerChannelFactory>().As<ITcpServerChannelFactory>().SingleInstance();
             builder.RegisterType<RpcServer>().As<IRpcServer>().SingleInstance();
             builder.RegisterType<RpcServerSettings>().As<IRpcServerSettings>();
+
+            builder.RegisterBuildCallback(async container =>
+            {
+                var logger = container.Resolve<ILogger>();
+                try
+                {
+                    var rpcServer = container.Resolve<IRpcServer>();
+                    await rpcServer.StartAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    logger.Error(e, "Error loading API");
+                }
+            });
+            
+            base.Load(builder);
         }  
     }
 }

--- a/src/Catalyst.TestUtils/FileSystemBasedTest.cs
+++ b/src/Catalyst.TestUtils/FileSystemBasedTest.cs
@@ -54,7 +54,9 @@ namespace Catalyst.TestUtils
         protected List<string> ConfigFilesUsed { get; }
         protected readonly ContainerProvider ContainerProvider;
 
-        protected FileSystemBasedTest(ITestOutputHelper output, IEnumerable<string> configFilesUsed = default, NetworkType network = default)
+        protected FileSystemBasedTest(ITestOutputHelper output, 
+            IEnumerable<string> configFilesUsed = default,
+            NetworkType network = default)
         {
             Guard.Argument(output, nameof(output)).NotNull();
             Output = output;
@@ -69,7 +71,7 @@ namespace Catalyst.TestUtils
 
             CurrentTestName = currentTest.TestCase.TestMethod.Method.Name;
 
-            GenerateConfigFilesDirectory();
+            CreateUniqueTestDirectory();
             
             ConfigFilesUsed = new List<string>
             {
@@ -88,7 +90,7 @@ namespace Catalyst.TestUtils
             Output.WriteLine("test running in folder {0}", _testDirectory.FullName);
         }
 
-        protected void GenerateConfigFilesDirectory()
+        protected void CreateUniqueTestDirectory()
         {
             var testStartTime = DateTime.Now;
             _testDirectory = new DirectoryInfo(Path.Combine(Environment.CurrentDirectory,
@@ -118,7 +120,7 @@ namespace Catalyst.TestUtils
                 return;
             }
 
-            var regex = new Regex(CurrentTestName + @"_(?<timestamp>[\d]{14})");
+            var regex = new Regex(CurrentTestName + @"_(?<timestamp>[\d]{16})");
 
             var oldDirectories = _testDirectory.Parent.EnumerateDirectories()
                .Where(d => regex.IsMatch(d.Name)

--- a/src/Catalyst.TestUtils/PeerSettingsHelper.cs
+++ b/src/Catalyst.TestUtils/PeerSettingsHelper.cs
@@ -25,7 +25,9 @@ using System.Collections.Generic;
 using System.Net;
 using Catalyst.Abstractions.P2P;
 using Catalyst.Abstractions.Rpc;
+using Catalyst.Core.Lib.Extensions;
 using Catalyst.Core.Lib.Util;
+using Catalyst.Core.Modules.Cryptography.BulletProofs;
 using Catalyst.Protocol.Network;
 using NSubstitute;
 
@@ -35,10 +37,10 @@ namespace Catalyst.TestUtils
     {
         public static IPeerSettings TestPeerSettings(byte[] publicKey = default, int port = 42069)
         {
+            var finalPublicKey = publicKey ?? ByteUtil.GenerateRandomByteArray(Ffi.PublicKeyLength);
             var peerSettings = Substitute.For<IPeerSettings>();
             peerSettings.NetworkType.Returns(NetworkType.Devnet);
-            peerSettings.PublicKey.Returns(
-                publicKey?.KeyToString() ?? TestKeyRegistry.TestPublicKey);
+            peerSettings.PublicKey.Returns(finalPublicKey.KeyToString());
             peerSettings.Port.Returns(port);
             peerSettings.PayoutAddress.Returns("my_pay_out_address");
             peerSettings.BindAddress.Returns(IPAddress.Loopback);
@@ -51,6 +53,7 @@ namespace Catalyst.TestUtils
                 "seed4.catalystnetwork.io",
                 "seed5.catalystnetwork.io"
             });
+            peerSettings.PeerId.Returns(finalPublicKey.BuildPeerIdFromPublicKey(IPAddress.Loopback, port));
             return peerSettings;
         }
     }


### PR DESCRIPTION
### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [x] I have added tests to cover my changes.
4. [x] All new and existing tests passed.
5. [x] Have you lint your code locally prior to submission?
6. [x] Does your code follows the code style of this project?
7. [ ] Does your change require a change to the documentation.
    - [ ] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [x] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [x] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
RpcServerModule should start on its own so we don't need to include it when building a node.
FileSystemBasedTest wasn't cleaning after itself anymore

* **What is the current behavior?** (You can also link to an open issue here)
RpcServerModule should start on its own so we don't need to include it when building a node.
FileSystemBasedTest wasn't cleaning after itself anymore

* **What is the new behavior (if this is a feature change)?**
RpcServer auto starts on resolution, FIleSystemBased test cleans after itself

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
