### PR TITLE
Fix sigint issue with api module to stop blocking ctrl-c to exit

### DIFF
--- a/src/Catalyst.Core.Modules.Web3/ApiModule.cs
+++ b/src/Catalyst.Core.Modules.Web3/ApiModule.cs
@@ -76,8 +76,9 @@ namespace Catalyst.Core.Modules.Web3
 
                 try
                 {
-                    var host = Host.CreateDefaultBuilder()
+                    await Host.CreateDefaultBuilder()
                        .UseServiceProviderFactory(new AutofacServiceProviderFactory())
+                       .UseConsoleLifetime()
                        .ConfigureContainer<ContainerBuilder>(ConfigureContainer)
                        .ConfigureWebHostDefaults(
                             webHostBuilder =>
@@ -88,8 +89,10 @@ namespace Catalyst.Core.Modules.Web3
                                    .UseUrls(_apiBindingAddress)
                                    .UseWebRoot(webDirectory.FullName)
                                    .UseSerilog();
-                            }).Build();
-                    await host.StartAsync();
+                            }).RunConsoleAsync();
+
+                    //SIGINT is caught from kestrel because we are using RunConsoleAsync in HostBuilder, the SIGINT will not be received in the main console so we need to exit the process manually, to prevent needing to use two SIGINT's
+                    Environment.Exit(2);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
### New Pull Request Submissions:

1. [x] Have you followed the guidelines in our [Contributing document](https://github.com/atlascity/Community/tree/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
3. [x] I have added tests to cover my changes.
4. [x] All new and existing tests passed.
5. [x] Have you lint your code locally prior to submission?
6. [x] Does your code follows the code style of this project?
7. [x] Does your change require a change to the documentation.
    - [ ] I have updated the documentation accordingly.
9. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
10. [x] Have you inserted a keyword and link to the issues the PR closes in its descriptions (ex `closes #1`) ?
11. [x] Is you branch up to date, have you integrated all the latest changes from develop and resolved conflicts ?

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
* **What is the current behavior?** (You can also link to an open issue here)
Sigint is being blocked by the ApiModule kestrel server
* **What is the new behavior (if this is a feature change)?**
Sigint can now close the app
* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
closes #1163 #1139 